### PR TITLE
SDC-17096: Support subscribe to topics matching specified pattern in Kafka multi topic consumer

### DIFF
--- a/kafka_multisource-0_10-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_10/loader/Kafka0_10ConsumerLoader.java
+++ b/kafka_multisource-0_10-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_10/loader/Kafka0_10ConsumerLoader.java
@@ -21,6 +21,9 @@ import com.streamsets.pipeline.lib.kafka.KafkaAutoOffsetReset;
 import com.streamsets.pipeline.lib.kafka.KafkaErrors;
 import com.streamsets.pipeline.stage.origin.multikafka.MultiSdcKafkaConsumer;
 import com.streamsets.pipeline.stage.origin.multikafka.loader.KafkaConsumerLoader;
+
+import java.util.regex.Pattern;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -28,6 +31,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
@@ -156,6 +160,11 @@ public class Kafka0_10ConsumerLoader extends KafkaConsumerLoader {
     @Override
     public void subscribe(List topics) {
       delegate.subscribe(topics);
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+      delegate.subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override

--- a/kafka_multisource-0_9-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_9/loader/Kafka0_9ConsumerLoader.java
+++ b/kafka_multisource-0_9-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_9/loader/Kafka0_9ConsumerLoader.java
@@ -21,11 +21,15 @@ import com.streamsets.pipeline.lib.kafka.KafkaAutoOffsetReset;
 import com.streamsets.pipeline.lib.kafka.KafkaErrors;
 import com.streamsets.pipeline.stage.origin.multikafka.MultiSdcKafkaConsumer;
 import com.streamsets.pipeline.stage.origin.multikafka.loader.KafkaConsumerLoader;
+
+import java.util.regex.Pattern;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.List;
@@ -70,6 +74,11 @@ public class Kafka0_9ConsumerLoader extends KafkaConsumerLoader {
     @Override
     public void subscribe(List topics) {
       delegate.subscribe(topics);
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+      delegate.subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override

--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaBeanConfig.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaBeanConfig.java
@@ -75,14 +75,40 @@ public class MultiKafkaBeanConfig {
 
   @ConfigDef(
       required = true,
+      type = ConfigDef.Type.BOOLEAN,
+      defaultValue = "true",
+      label = "Topic Name Match Exactly",
+      description = "Whether use topic regex pattern",
+      displayPosition = 21,
+      group = "KAFKA"
+  )
+  public boolean notUsingPattern;
+
+  @ConfigDef(
+      required = true,
       type = ConfigDef.Type.LIST,
       defaultValue = "[\"myTopic\"]",
       label = "Topic List",
       description = "List of topics to consume",
+      dependsOn = "notUsingPattern",
+      triggeredByValue = {"true"},
       displayPosition = 30,
       group = "KAFKA"
   )
   public List<String> topicList = new ArrayList<>();
+
+  @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.STRING,
+      defaultValue = "",
+      label = "Topic Pattern",
+      description = "Topic Pattern using regular expression, ",
+      dependsOn = "notUsingPattern",
+      triggeredByValue = {"false"},
+      displayPosition = 40,
+      group = "KAFKA"
+  )
+  public String topicPattern;
 
   @ConfigDef(
       required = true,

--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaSource.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaSource.java
@@ -115,12 +115,20 @@ public class MultiKafkaSource extends BasePushSource {
     }
 
     executor = Executors.newFixedThreadPool(getNumberOfThreads());
-    for (String topic : conf.topicList) {
-      LineageEvent event = getContext().createLineageEvent(LineageEventType.ENTITY_READ);
+    if (conf.notUsingPattern) {
+      for (String topic : conf.topicList) {
+        LineageEvent event = getContext().createLineageEvent(LineageEventType.ENTITY_READ);
+        event.setSpecificAttribute(LineageSpecificAttribute.ENDPOINT_TYPE, EndPointType.KAFKA.name());
+        event.setSpecificAttribute(LineageSpecificAttribute.ENTITY_NAME, topic);
+        event.setSpecificAttribute(LineageSpecificAttribute.DESCRIPTION, conf.connectionConfig.connection.metadataBrokerList);
+        getContext().publishLineageEvent(event);
+      }
+    } else {
+      LineageEvent event = (getContext()).createLineageEvent(LineageEventType.ENTITY_READ);
       event.setSpecificAttribute(LineageSpecificAttribute.ENDPOINT_TYPE, EndPointType.KAFKA.name());
-      event.setSpecificAttribute(LineageSpecificAttribute.ENTITY_NAME, topic);
+      event.setSpecificAttribute(LineageSpecificAttribute.ENTITY_NAME, this.conf.topicPattern);
       event.setSpecificAttribute(LineageSpecificAttribute.DESCRIPTION, conf.connectionConfig.connection.metadataBrokerList);
-      getContext().publishLineageEvent(event);
+      (getContext()).publishLineageEvent(event);
     }
     return issues;
   }

--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiSdcKafkaConsumer.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiSdcKafkaConsumer.java
@@ -15,6 +15,8 @@
  */
 package com.streamsets.pipeline.stage.origin.multikafka;
 
+import java.util.regex.Pattern;
+
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -31,6 +33,8 @@ public interface MultiSdcKafkaConsumer<K, V> {
 
   void subscribe(List<String> topics);
 
+  void subscribe(Pattern var1);
+
   ConsumerRecords<K, V> poll(long timeout);
 
   void unsubscribe();
@@ -38,4 +42,5 @@ public interface MultiSdcKafkaConsumer<K, V> {
   void close();
 
   void commitSync(Map<TopicPartition, OffsetAndMetadata> offsetsMap);
+
 }

--- a/kafka_multisource-protolib/src/test/java/com/streamsets/pipeline/stage/origin/multikafka/loader/MockKafkaConsumerLoader.java
+++ b/kafka_multisource-protolib/src/test/java/com/streamsets/pipeline/stage/origin/multikafka/loader/MockKafkaConsumerLoader.java
@@ -19,9 +19,13 @@ import com.streamsets.pipeline.api.Stage;
 import com.streamsets.pipeline.api.StageException;
 import com.streamsets.pipeline.lib.kafka.KafkaAutoOffsetReset;
 import com.streamsets.pipeline.stage.origin.multikafka.MultiSdcKafkaConsumer;
+
+import java.util.regex.Pattern;
+
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Iterator;
@@ -74,6 +78,11 @@ public class MockKafkaConsumerLoader extends KafkaConsumerLoader {
     @Override
     public void subscribe(List topics) {
       delegate.subscribe(topics);
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+      delegate.subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,10 @@
     <wholefile-transformer-lib>wholefile-transformer-lib</wholefile-transformer-lib>
     <windows-lib>windows-lib</windows-lib>
     <rootProject>true</rootProject>
-    <datacollector-api.version>3.23.0-SNAPSHOT</datacollector-api.version>
-    <datacollector-spark-api.version>3.23.0-SNAPSHOT</datacollector-spark-api.version>
+    <datacollector-api.version>3.22.3</datacollector-api.version>
+    <!--<datacollector-api.version>3.23.0-SNAPSHOT</datacollector-api.version>-->
+    <!--<datacollector-spark-api.version>3.23.0-SNAPSHOT</datacollector-spark-api.version>-->
+    <datacollector-spark-api.version>3.22.3</datacollector-spark-api.version>
     <thycotic-credentialstore-lib>thycotic-credentialstore-lib</thycotic-credentialstore-lib>
   </properties>
 
@@ -248,7 +250,7 @@
     <module>scripting-protolib</module>
     <module>wholefile-converter-protolib</module>
     <module>emr-protolib</module>
-    <module>databricks-ml-protolib</module>
+<!--    <module>databricks-ml-protolib</module>-->
 
     <!--
          Stage libraries that always built with the data collector (they dont have protolibs)

--- a/sdc-kafka_0_8/pom.xml
+++ b/sdc-kafka_0_8/pom.xml
@@ -61,13 +61,13 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.streamsets</groupId>
-      <artifactId>streamsets-datacollector-kafka-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>compile</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>com.streamsets</groupId>-->
+<!--      <artifactId>streamsets-datacollector-kafka-common</artifactId>-->
+<!--      <version>${project.version}</version>-->
+<!--      <type>test-jar</type>-->
+<!--      <scope>compile</scope>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>com.streamsets</groupId>
       <artifactId>streamsets-datacollector-api</artifactId>


### PR DESCRIPTION
Kafka MultiTopic Consumer can support consumer to subscribe to topics with accurate names, but do not support patterns in the topic names. We often encounter such scenarios. For example, we need to subscribe to topics starting with elk*, so we hope that topic names can support pattern, so that we don’t have to modify and restart the pipeline every time.